### PR TITLE
generate named token IDs for various uses

### DIFF
--- a/lemon_rust.c
+++ b/lemon_rust.c
@@ -3755,6 +3755,13 @@ void ReportTable(
   }
   fprintf(out,"}\n"); lineno++;
 
+  fprintf(out,"const TOKEN_EOI: i32 = 0;\n");
+  lineno++;
+  for(i=1; i<lemp->nterminal; i++){
+    fprintf(out,"const TOKEN_%s: i32 = %d;\n",lemp->symbols[i]->name,i);
+    lineno++;
+  }
+
   fprintf(out,"#[inline]\n"); lineno++;
   fprintf(out,"fn token_major(t: &Token) -> i32 {\n"); lineno++;
   fprintf(out,"    unsafe { ::std::intrinsics::discriminant_value(t) as i32}\n"); lineno++;

--- a/lemon_rust.c
+++ b/lemon_rust.c
@@ -3772,7 +3772,17 @@ void ReportTable(
 
   fprintf(out,"#[inline]\n"); lineno++;
   fprintf(out,"fn token_major(t: &Token) -> i32 {\n"); lineno++;
-  fprintf(out,"    unsafe { ::std::intrinsics::discriminant_value(t) as i32}\n"); lineno++;
+  fprintf(out,"    match t {\n"); lineno++;
+  fprintf(out,"        &Token::EOI => 0,\n");
+  for(i=1; i<lemp->nterminal; i++){
+    if(lemp->symbols[i]->datatype){
+      fprintf(out,"        &Token::%s(_) => TOKEN_%s,\n",lemp->symbols[i]->name,lemp->symbols[i]->name);
+    }else{
+      fprintf(out,"        &Token::%s => TOKEN_%s,\n",lemp->symbols[i]->name,lemp->symbols[i]->name);
+    }
+    lineno++;
+  }
+  fprintf(out,"    }\n"); lineno++;
   fprintf(out,"}\n"); lineno++;
   fprintf(out,"#[inline]\n"); lineno++;
   fprintf(out,"fn token_minor(t: Token) -> YYMinorType {\n"); lineno++;

--- a/lemon_rust.c
+++ b/lemon_rust.c
@@ -3763,10 +3763,10 @@ void ReportTable(
   }
   fprintf(out,"}\n"); lineno++;
 
-  fprintf(out,"const TOKEN_EOI: i32 = 0;\n");
+  fprintf(out,"pub const TOKEN_EOI: i32 = 0;\n");
   lineno++;
   for(i=1; i<lemp->nterminal; i++){
-    fprintf(out,"const TOKEN_%s: i32 = %d;\n",lemp->symbols[i]->name,i);
+    fprintf(out,"pub const TOKEN_%s: i32 = %d;\n",lemp->symbols[i]->name,i);
     lineno++;
   }
 


### PR DESCRIPTION
1. Assign fixed ID values to each tokens and write them as constants in the Rust file
2. Then return them from the  `token_major()` function which now matches on the token parameter instead of using unstable intrinsic function `discriminant_value()` which fixes github issue #2
3. Finally, if the -H option is passed, emit a C header w/ a `#define` for each token type and it's assigned token ID

Here's the [diff](https://gist.github.com/mdg/1097315f61511d2e17ac) for how this changes the generated parser for the example parser in the repo.
