### PR TITLE
Markdown Fixes

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,9 +1,9 @@
-#The Lemon\_Rust Parser Generator
+# The Lemon_Rust Parser Generator
 
-Lemon\_Rust is a port to Rust of the Lemon Parser Generator (from now on, Lemon\_C) originally written by D. Richard Hipp for his SQLite parser.
+Lemon_Rust is a port to Rust of the Lemon Parser Generator (from now on, Lemon_C) originally written by D. Richard Hipp for his SQLite parser.
 The program itself it is still written in C, but the generated code is 100% Rust.
 
-This Lemon\_Rust guide is shamelessly based on the original [Lemon\_C guide](http://www.hwaci.com/sw/lemon/lemon.html).
+This Lemon_Rust guide is shamelessly based on the original [Lemon_C guide](http://www.hwaci.com/sw/lemon/lemon.html).
 
 *Lemon* is an LALR(1) parser generator for Rust. It does the same job as *bison* and *yacc*. But *lemon* is not another *bison* or *yacc* clone.
 It uses a different grammar syntax which is designed to reduce the number of coding errors.
@@ -117,7 +117,7 @@ There is one other interface routine that should be mentioned before we move on.
 
    ParseTrace(FILE *stream, char *zPrefix);
 After this routine is called, a short (one-line) message is written to the designated output stream every time the parser changes states or calls an action routine. Each such message is prefaced using the text given by zPrefix. This debugging output can be turned off by calling ParseTrace() again with a first argument of NULL (0).
- --> 
+ -->
 
 ## Differences With *yacc* and *bison*
 
@@ -141,7 +141,7 @@ A terminal symbol (token) is any string of alphanumeric and underscore character
 
 In *lemon*, terminal and nonterminal symbols do not need to be declared or identified in a separate section of the grammar file. *lemon* is able to generate a list of all terminals and nonterminals by examining the grammar rules, and it can always distinguish a terminal from a nonterminal by checking the case of the first character of the name.
 
-*yacc* and *bison* allow terminal symbols to have either alphanumeric names or to be individual characters included in single quotes, like this: ')' or '$'. *lemon* does not allow this alternative form for terminal symbols. With *lemon*, all symbols, terminals and nonterminals, must have alphanumeric names.
+*yacc* and *bison* allow terminal symbols to have either alphanumeric names or to be individual characters included in single quotes, like this: `')'` or `'$'`. *Lemon* does not allow this alternative form for terminal symbols. With *lemon*, all symbols, terminals and nonterminals, must have alphanumeric names.
 
 ### Grammar Rules
 
@@ -154,7 +154,7 @@ The main component of a *lemon* grammar file is a sequence of grammar rules. Eac
 
 There is one non-terminal in this example, `expr`, and five terminal symbols or tokens: `PLUS`, `TIMES`, `LPAREN`, `RPAREN` and `VALUE`.
 
-Like *yacc* and *bison*, *lemon* allows the grammar to specify a block of code that will be executed whenever a grammar rule is reduced by the parser. In *lemon*, this action is specified by putting the code (contained within curly braces {...}) immediately after the period that closes the rule. For example:
+Like *yacc* and *bison*, *lemon* allows the grammar to specify a block of code that will be executed whenever a grammar rule is reduced by the parser. In *lemon*, this action is specified by putting the code (contained within curly braces `{`...`}`) immediately after the period that closes the rule. For example:
 
     expr ::= expr PLUS expr.   { println!("Doing an addition..."); }
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-# Lemon\_Rust
+# Lemon_Rust
 
 A port of the Lemon Parser Generator  to Rust.
 
-##Introduction
+## Introduction
 
 From the original [Lemon documentation](http://www.hwaci.com/sw/lemon/lemon.html):
 
-> Lemon is an LALR(1) parser generator for C or C++. It does the same job as ``bison'' and ``yacc''. But lemon is not another bison or yacc clone. It uses a different grammar syntax which is designed to reduce the number of coding errors. Lemon also uses a more sophisticated parsing engine that is faster than yacc and bison and which is both reentrant and thread-safe.
+> Lemon is an LALR(1) parser generator for C or C++. It does the same job as "bison" and "yacc". But lemon is not another bison or yacc clone. It uses a different grammar syntax which is designed to reduce the number of coding errors. Lemon also uses a more sophisticated parsing engine that is faster than yacc and bison and which is both reentrant and thread-safe.
 
-Change _C or C++_ to _Rust_ and you will get also the [well known benefits](http://www.rust-lang.org/) of this language.
+Change _C_ or _C++_ to _Rust_ and you will get also the [well known benefits](http://www.rust-lang.org/) of this language.
 
 My thanks and acknowledgement to D. Richard Hipp, the original creator of Lemon.
 
-##Differences between Lemon\_C and Lemon\_Rust
+## Differences between Lemon_C and Lemon_Rust
 
-Lemon\_Rust works basically the same as Lemon\_C. The main difference is, obviously, that it generates Rust code instead of C code. However there are a few other differences, due to the differences in the generated languages.
+Lemon_Rust works basically the same as Lemon_C. The main difference is, obviously, that it generates Rust code instead of C code. However there are a few other differences, due to the differences in the generated languages.
 
 In the grammar file there are basically the following differences:
 
 1. There is no `%name` or `%token_prefix`directives. In C all the symbol names are global so this directive allows you to change the name of the generated symbols. In Rust, the generated file will be compiled as a _crate_ and it will have its own namespace.  So changing the names of the generated symbols is not needed.
 2. There are no destructors (`%destructor`, `%token_destructor` and `%default_destructor`). If you need to write destructors, just implement the `Drop` trait for the associated type.
-3. There is no `%token_type` directive. In Lemon\_C, all tokens must have the same type, while non-terminal symbols may have different types. In Lemon\_Rust there is no such distinctions, so you can specify the type for each individual token with ` %type`.
+3. There is no `%token_type` directive. In Lemon_C, all tokens must have the same type, while non-terminal symbols may have different types. In Lemon_Rust there is no such distinctions, so you can specify the type for each individual token with ` %type`.
 4. There is a new `%derive_token` directive. It is used to add the `#[derive()]` directive to the generated `Token` type.
 
 In the invocation of the program:
@@ -28,6 +28,6 @@ In the invocation of the program:
 1. There is no `-m` option. That was for writing a `makeheaders` file, but Rust does not need that.
 2. The default template file is not `lempar.c` but `lempar.rs`.
 
-##Detailed documentation
+## Detailed documentation
 
-See the DOCUMENTATION.md file included in the source tree.
+See the [`DOCUMENTATION.md`](./DOCUMENTATION.md) file included in the source tree.


### PR DESCRIPTION
Fix malformed markdown elements in markdown docs:

- Broken headings due missing space after `#`.
- Fix stray in-line-code/quotes.
- Minor formatting fixes.
- Remove superfluous escapes.
- Add in-line code formatting in a couple of places.
- Minor letter-case fixes.

In `README.md:`

- Convert reference to `DOCUMENTATION.md` file into a link.